### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "redkiwi-nl/localconfig",
     "description": "Creates a local config for any WordPress installation, based on a few questions you get asked.",
+    "type": "wp-cli-package",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
